### PR TITLE
feat: add MM-TSFlib benchmark comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,6 @@ wandb/
 
 # Time-MMD dataset (cloned via scripts/clone_time_mmd.sh)
 data/Time-MMD/
+
+# External repos
+third_party/

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ Split the dataset into train / val / test:
 
 ```sh
 PYTHONPATH=. uv run python scripts/split_time_mmd_datasets.py \
-    --train-ratio 0.6 \
-    --val-ratio 0.2
+    --train-ratio 0.7 \
+    --val-ratio 0.1
 ```
 
 ### 2. Pre-compute Text Embeddings
@@ -133,6 +133,36 @@ PYTHONPATH=. uv run python scripts/visualize_time_mmd_predictions.py \
 ```
 
 Use `--max-samples N` to limit the number of plots per split, and `--splits train val test` to select which splits to visualize.
+
+## Benchmark Comparison with MM-TSFlib
+
+[MM-TSFlib](https://github.com/AdityaLab/MM-TSFlib) is cloned under `third_party/MM-TSFlib` (not tracked by git). MM-TSFlib is run on its own pre-processed Time-MMD CSVs; tsfmx is evaluated on the raw Time-MMD data split 70/10/20. Both cover the same underlying domains and split ratio.
+
+```sh
+./scripts/setup_mm_tsflib.sh
+```
+
+### 1. Run MM-TSFlib benchmark
+
+```sh
+./scripts/run_mm_tsflib_benchmark.sh 0 Autoformer <HF_TOKEN>
+```
+
+Requires a HuggingFace token with access to LLaMA 3.
+
+### 2. Evaluate tsfmx checkpoint
+
+```sh
+PYTHONPATH=. uv run python scripts/eval_tsfmx_checkpoint.py \
+    --model-config examples/time_mmd/configs/models/timesfm.yml \
+    --checkpoint-path outputs/sweeps/fusion/best_checkpoints/best_val_loss.pt
+```
+
+### 3. Compare results
+
+```sh
+PYTHONPATH=. uv run python scripts/compare_benchmark_results.py
+```
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Use `--max-samples N` to limit the number of plots per split, and `--splits trai
 ### 1. Run MM-TSFlib benchmark
 
 ```sh
-./scripts/run_mm_tsflib_benchmark.sh 0 Autoformer <HF_TOKEN>
+./scripts/run_mm_tsflib_benchmark.sh 0 Autoformer YOUR_HF_TOKEN
 ```
 
 Requires a HuggingFace token with access to LLaMA 3.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,15 @@
 FROM nvidia/cuda:13.0.2-cudnn-devel-ubuntu24.04
 RUN apt update -y && \
-  apt install -y wget git && \
+  apt install -y wget git libarchive-tools && \
   wget -qO- https://astral.sh/uv/install.sh | sh
 ENV PATH="/root/.local/bin:$PATH"
 RUN git clone https://github.com/himura467/tsfmx.git && \
   cd tsfmx && \
   ./scripts/clone_time_mmd.sh && \
-  uv sync --extra sweep
+  ./scripts/setup_mm_tsflib.sh && \
+  uv sync --extra sweep --extra bench
 WORKDIR /tsfmx
 ENV PYTHONPATH=/tsfmx
 RUN uv run python scripts/split_time_mmd_datasets.py \
-  --train-ratio 0.6 \
-  --val-ratio 0.2
+  --train-ratio 0.7 \
+  --val-ratio 0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,12 @@ sweep = [
 viz = [
     "matplotlib>=3.10.9",
 ]
+bench = [
+    "scikit-learn>=1.8.0",
+]
 all = [
     "matplotlib>=3.10.9",
+    "scikit-learn>=1.8.0",
     "wandb>=0.25.0",
 ]
 

--- a/scripts/clone_mm_tsflib.sh
+++ b/scripts/clone_mm_tsflib.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+MM_DIR="$REPO_DIR/third_party/MM-TSFlib"
+
+if [[ -d "$MM_DIR" ]]; then
+  echo "MM-TSFlib already exists at $MM_DIR, skipping clone."
+else
+  mkdir -p "$REPO_DIR/third_party"
+  git clone --depth 1 https://github.com/AdityaLab/MM-TSFlib.git "$MM_DIR"
+  echo "MM-TSFlib cloned to $MM_DIR."
+fi

--- a/scripts/compare_benchmark_results.py
+++ b/scripts/compare_benchmark_results.py
@@ -39,8 +39,8 @@ def _load_mm_tsflib(path: Path) -> dict[str, dict[str, float]]:
         if not line:
             continue
         if "mse:" in line and setting:
-            parsed = {k: float(v) for k, v in re.findall(r"(\w+):([\d.eE+\-]+)", line)}
-            if "mse" in parsed:
+            parsed = {k: float(v) for k, v in re.findall(r"(\w+):\s*([\d.eE+\-]+)", line)}
+            if "mse" in parsed and "mae" in parsed:
                 m = re.match(r"^(.+?)_\d+_\d+_LLAMA3", setting)
                 if m:
                     domain = _MM_DOMAIN_ALIASES.get(m.group(1), m.group(1))

--- a/scripts/compare_benchmark_results.py
+++ b/scripts/compare_benchmark_results.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Print a comparison table of tsfmx vs MM-TSFlib per-domain MSE/MAE."""
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+_MM_DOMAIN_ALIASES: dict[str, str] = {
+    "Algriculture": "Agriculture",
+    "Public_Health": "Health_US",
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--tsfmx", default="outputs/tsfmx_eval_results.json")
+    parser.add_argument("--mm-tsflib", default="third_party/MM-TSFlib/result_longterm_forecast")
+
+    return parser.parse_args()
+
+
+def _load_tsfmx(path: Path) -> dict[str, dict[str, float]]:
+    if not path.exists():
+        print(f"[warn] not found: {path}")
+        return {}
+    return json.loads(path.read_text())
+
+
+def _load_mm_tsflib(path: Path) -> dict[str, dict[str, float]]:
+    if not path.exists():
+        print(f"[warn] not found: {path}")
+        return {}
+    results: dict[str, dict[str, float]] = {}
+    setting = ""
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if "mse:" in line and setting:
+            parsed = {k: float(v) for k, v in re.findall(r"(\w+):([\d.eE+\-]+)", line)}
+            if "mse" in parsed:
+                m = re.match(r"^(.+?)_\d+_\d+_LLAMA3", setting)
+                if m:
+                    domain = _MM_DOMAIN_ALIASES.get(m.group(1), m.group(1))
+                    results[domain] = {"mse": parsed["mse"], "mae": parsed["mae"]}
+            setting = ""
+        else:
+            setting = line
+    return results
+
+
+def _col(v: float | None) -> str:
+    return f"{v:.5f}".rjust(12) if v is not None else "N/A".rjust(12)
+
+
+def _avg(xs: list[float]) -> float | None:
+    return sum(xs) / len(xs) if xs else None
+
+
+def main() -> None:
+    args = _parse_args()
+
+    tsfmx = _load_tsfmx(Path(args.tsfmx))
+    mm = _load_mm_tsflib(Path(args.mm_tsflib))
+
+    domains = sorted(set(tsfmx) | set(mm))
+    if not domains:
+        print("No results. Run both benchmarks first.")
+        return
+
+    header = f"{'Domain':<20}{'tsfmx MSE':>12}{'tsfmx MAE':>12}{'MM-TSF MSE':>12}{'MM-TSF MAE':>12}"
+    sep = "-" * len(header)
+    print("=" * len(header))
+    print("tsfmx vs MM-TSFlib (LLAMA3+Autoformer) | Time-MMD | ctx=32 hz=32 split=70/10/20")
+    print("=" * len(header))
+    print(header)
+    print(sep)
+
+    t_mses, t_maes, m_mses, m_maes = [], [], [], []
+    for domain in domains:
+        t = tsfmx.get(domain, {})
+        m = mm.get(domain, {})
+        print(f"{domain:<20}{_col(t.get('mse'))}{_col(t.get('mae'))}{_col(m.get('mse'))}{_col(m.get('mae'))}")
+        if "mse" in t:
+            t_mses.append(t["mse"])
+            t_maes.append(t["mae"])
+        if "mse" in m:
+            m_mses.append(m["mse"])
+            m_maes.append(m["mae"])
+
+    if t_mses or m_mses:
+        print(sep)
+        print(f"{'Mean':<20}{_col(_avg(t_mses))}{_col(_avg(t_maes))}{_col(_avg(m_mses))}{_col(_avg(m_maes))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/eval_tsfmx_checkpoint.py
+++ b/scripts/eval_tsfmx_checkpoint.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Evaluate a tsfmx checkpoint on Time-MMD test splits and write per-domain MSE/MAE to JSON."""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, cast
+
+import torch
+from torch.utils.data import ConcatDataset, DataLoader
+
+from examples.time_mmd.configs.forecast import ForecastConfig
+from examples.time_mmd.configs.model import ModelConfig
+from examples.time_mmd.cross_validation import DomainSpec, load_fold_datasets
+from tsfmx.data.collate import adapter_collate_fn, multimodal_collate_fn
+from tsfmx.decoder import MultimodalDecoder, MultimodalDecoderConfig
+from tsfmx.evaluator import MultimodalEvaluator
+from tsfmx.tsfm.base import TsfmAdapter
+from tsfmx.tsfm.chronos import Chronos2Adapter
+from tsfmx.tsfm.timesfm import TimesFM2p5Adapter
+from tsfmx.types import Batch, TrainingMode
+from tsfmx.utils.device import pin_memory, resolve_device
+from tsfmx.utils.logging import setup_logger
+
+_logger = setup_logger()
+
+_DEFAULT_DOMAINS = ["Agriculture", "Economy", "Environment", "Health_US", "Traffic"]
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("--checkpoint-path", type=str, required=True)
+    parser.add_argument("--model-config", type=str)
+    parser.add_argument("--forecast-config", type=str)
+    parser.add_argument("--domains", nargs="+", default=_DEFAULT_DOMAINS)
+    parser.add_argument("--cache-dir", type=str, default="data/cache")
+    parser.add_argument("--output", type=str, default="outputs/tsfmx_eval_results.json")
+    parser.add_argument("--batch-size", type=int, default=8)
+
+    return parser.parse_args()
+
+
+def _make_loader(
+    dataset: ConcatDataset[Any], batch_size: int, collate_fn: Any, device: torch.device
+) -> DataLoader[Batch]:
+    return cast(
+        DataLoader[Batch],
+        DataLoader(
+            dataset,
+            batch_size=batch_size,
+            shuffle=False,
+            num_workers=0,
+            collate_fn=collate_fn,
+            pin_memory=pin_memory(device),
+        ),
+    )
+
+
+def main() -> int:
+    args = _parse_args()
+    model_config = ModelConfig.from_yaml(Path(args.model_config)) if args.model_config else ModelConfig()
+    forecast_config = ForecastConfig.from_yaml(Path(args.forecast_config)) if args.forecast_config else ForecastConfig()
+
+    device = resolve_device()
+    adapter: TsfmAdapter
+    match model_config.adapter.type:
+        case "chronos":
+            adapter = Chronos2Adapter.from_pretrained(device, repo_id=model_config.adapter.pretrained_repo)
+        case "timesfm":
+            adapter = TimesFM2p5Adapter.from_pretrained(device, repo_id=model_config.adapter.pretrained_repo)
+        case _ as t:
+            raise NotImplementedError(f"Unsupported adapter type: {t!r}")
+
+    model = MultimodalDecoder(
+        adapter,
+        MultimodalDecoderConfig(
+            text_embedding_dims=model_config.fusion.text_embedding_dims,
+            num_fusion_layers=model_config.fusion.num_fusion_layers,
+            fusion_hidden_dims=model_config.fusion.fusion_hidden_dims,
+        ),
+    ).to(device)
+
+    mode: TrainingMode = model.load_checkpoint(Path(args.checkpoint_path))
+    model.eval()
+
+    collate_fn = multimodal_collate_fn if mode in ("fusion", "finetune") else adapter_collate_fn
+    evaluator = MultimodalEvaluator(model, device)
+    results: dict[str, dict[str, float]] = {}
+
+    for domain in args.domains:
+        try:
+            _, _, test_dataset = load_fold_datasets(
+                train_domain_specs=[DomainSpec(name=f"{domain}_train")],
+                val_domain_specs=[DomainSpec(name=f"{domain}_val")],
+                test_domain_specs=[DomainSpec(name=f"{domain}_test")],
+                text_encoder_type=model_config.fusion.text_encoder_type,
+                patch_len=model_config.adapter.patch_len,
+                context_len=forecast_config.context_len,
+                horizon_len=forecast_config.horizon_len,
+                cache_dir=Path(args.cache_dir),
+                mode=mode,
+            )
+        except Exception as e:
+            _logger.warning("Skipping %s: %s", domain, e)
+            continue
+
+        metrics = evaluator.evaluate(_make_loader(test_dataset, args.batch_size, collate_fn, device))
+        results[domain] = {"mse": metrics["mse"], "mae": metrics["mae"]}
+        _logger.info("%s — MSE: %.6f  MAE: %.6f", domain, metrics["mse"], metrics["mae"])
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(results, f, indent=2)
+    _logger.info("Results written to %s", output_path)
+    return 0
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/scripts/run_mm_tsflib_benchmark.sh
+++ b/scripts/run_mm_tsflib_benchmark.sh
@@ -64,4 +64,4 @@ for domain in "${!DOMAIN_FILES[@]}"; do
         --huggingface_token "$HF_TOKEN"
 done
 
-echo "Done. Results in $MM_DIR/result_tsfmx_comparison"
+echo "Done. Results in $MM_DIR/result_longterm_forecast"

--- a/scripts/run_mm_tsflib_benchmark.sh
+++ b/scripts/run_mm_tsflib_benchmark.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Run MM-TSFlib on its own pre-processed Time-MMD data.
+# Results are appended to third_party/MM-TSFlib/result_longterm_forecast.
+# Compare with: PYTHONPATH=. uv run python scripts/compare_benchmark_results.py
+#
+# Usage: ./scripts/run_mm_tsflib_benchmark.sh [GPU_ID] [TS_MODEL] [HF_TOKEN]
+set -euo pipefail
+
+GPU=${1:-0}
+MODEL=${2:-"Autoformer"}
+HF_TOKEN=${3:-"NA"}
+
+SEQ_LEN=32   # matches tsfmx context_len
+PRED_LEN=32  # matches tsfmx horizon_len
+LABEL_LEN=16 # seq_len // 2, consistent with MM-TSFlib convention
+TEXT_LEN=4   # selects Final_Search_4; MM-TSFlib data only has Final_Search_2/4/6
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.."; pwd)"
+MM_DIR="$REPO_DIR/third_party/MM-TSFlib"
+DATA_ROOT="$MM_DIR/data"
+PYTHON="$REPO_DIR/.venv/bin/python"
+
+export CUDA_VISIBLE_DEVICES="$GPU"
+
+if [ ! -f "$PYTHON" ]; then
+    echo "Error: uv venv not found at $PYTHON. Run 'uv sync --extra bench' first." >&2
+    exit 1
+fi
+
+if [ ! -d "$MM_DIR" ]; then
+    echo "Error: MM-TSFlib not found at $MM_DIR. Run './scripts/setup_mm_tsflib.sh' first." >&2
+    exit 1
+fi
+
+# Only the 5 domains tsfmx was trained on.
+declare -A DOMAIN_FILES=(
+    ["Algriculture"]="US_RetailBroilerComposite_Month.csv"
+    ["Economy"]="US_TradeBalance_Month.csv"
+    ["Environment"]="NewYork_AQI_Day.csv"
+    ["Public_Health"]="US_FLURATIO_Week.csv"
+    ["Traffic"]="US_VMT_Month.csv"
+)
+
+cd "$MM_DIR"
+
+for domain in "${!DOMAIN_FILES[@]}"; do
+    data_file="${DOMAIN_FILES[$domain]}"
+    echo "=== $domain ($data_file) ==="
+    "$PYTHON" -u run.py \
+        --task_name long_term_forecast \
+        --is_training 1 \
+        --model_id "${domain}_${SEQ_LEN}_${PRED_LEN}_LLAMA3" \
+        --model "$MODEL" \
+        --data custom \
+        --root_path "$DATA_ROOT/$domain" \
+        --data_path "$data_file" \
+        --features S \
+        --seq_len $SEQ_LEN \
+        --label_len $LABEL_LEN \
+        --pred_len $PRED_LEN \
+        --llm_model LLAMA3 \
+        --text_len $TEXT_LEN \
+        --prompt_weight 0.1 \
+        --huggingface_token "$HF_TOKEN"
+done
+
+echo "Done. Results in $MM_DIR/result_tsfmx_comparison"

--- a/scripts/setup_mm_tsflib.sh
+++ b/scripts/setup_mm_tsflib.sh
@@ -12,3 +12,10 @@ else
   git clone --depth 1 https://github.com/AdityaLab/MM-TSFlib.git "$MM_DIR"
   echo "MM-TSFlib cloned to $MM_DIR."
 fi
+
+RAR="$MM_DIR/data/Environment/NewYork_AQI_Day.rar"
+CSV="$MM_DIR/data/Environment/NewYork_AQI_Day.csv"
+if [[ -f "$RAR" && ! -f "$CSV" ]]; then
+  bsdtar -xf "$RAR" -C "$MM_DIR/data/Environment/"
+  echo "Extracted Environment data."
+fi

--- a/scripts/split_time_mmd_datasets.py
+++ b/scripts/split_time_mmd_datasets.py
@@ -31,6 +31,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--data-path", type=str, default="data/Time-MMD")
     parser.add_argument("--train-ratio", type=float, required=True)
     parser.add_argument("--val-ratio", type=float, required=True)
+    parser.add_argument("--context-len", type=int, default=32)
     parser.add_argument("--domains", type=str, nargs="+")
     parser.add_argument("--force-rebuild", action="store_true", help="Overwrite existing split files.")
 
@@ -42,17 +43,10 @@ def _split_numerical(
     domain: str,
     train_ratio: float,
     val_ratio: float,
+    context_len: int,
     force_rebuild: bool,
 ) -> None:
-    """Split a domain's numerical CSV into train / val / test subsets.
-
-    Args:
-        numerical_dir: Path to the numerical/ directory.
-        domain: Domain name.
-        train_ratio: Fraction of rows for the training split.
-        val_ratio: Fraction of rows for the validation split.
-        force_rebuild: Overwrite existing split files when True.
-    """
+    """Split a domain's numerical CSV into train / val / test subsets with context overlap."""
     src = numerical_dir / domain / f"{domain}.csv"
     if not src.exists():
         _logger.warning("Numerical file not found, skipping: %s", src)
@@ -70,8 +64,8 @@ def _split_numerical(
     val_end = int(n * (train_ratio + val_ratio))
     slices: dict[Split, pd.DataFrame] = {
         "train": df.iloc[:train_end],
-        "val": df.iloc[train_end:val_end],
-        "test": df.iloc[val_end:],
+        "val": df.iloc[max(0, train_end - context_len) : val_end],
+        "test": df.iloc[max(0, val_end - context_len) :],
     }
 
     for split in _SPLITS:
@@ -150,10 +144,11 @@ def main() -> int:
     test_ratio = 1.0 - args.train_ratio - args.val_ratio
     _logger.info("Domains: %s", domains)
     _logger.info("Ratios — train: %s, val: %s, test: %.2f", args.train_ratio, args.val_ratio, test_ratio)
+    _logger.info("Context overlap prefix: %d rows", args.context_len)
 
     for domain in domains:
         _logger.info("Processing domain: %s", domain)
-        _split_numerical(numerical_dir, domain, args.train_ratio, args.val_ratio, args.force_rebuild)
+        _split_numerical(numerical_dir, domain, args.train_ratio, args.val_ratio, args.context_len, args.force_rebuild)
         _duplicate_textual(textual_dir, domain, args.force_rebuild)
 
     _logger.info("All domains processed successfully")

--- a/uv.lock
+++ b/uv.lock
@@ -2130,7 +2130,11 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "matplotlib" },
+    { name = "scikit-learn" },
     { name = "wandb" },
+]
+bench = [
+    { name = "scikit-learn" },
 ]
 sweep = [
     { name = "wandb" },
@@ -2157,6 +2161,8 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.4.2" },
     { name = "pandas", specifier = ">=2.3.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "scikit-learn", marker = "extra == 'all'", specifier = ">=1.8.0" },
+    { name = "scikit-learn", marker = "extra == 'bench'", specifier = ">=1.8.0" },
     { name = "sentence-transformers", specifier = ">=5.1.0" },
     { name = "sentencepiece", specifier = ">=0.2.1" },
     { name = "timesfm", extras = ["torch"], git = "https://github.com/google-research/timesfm" },
@@ -2165,7 +2171,7 @@ requires-dist = [
     { name = "wandb", marker = "extra == 'all'", specifier = ">=0.25.0" },
     { name = "wandb", marker = "extra == 'sweep'", specifier = ">=0.25.0" },
 ]
-provides-extras = ["sweep", "viz", "all"]
+provides-extras = ["sweep", "viz", "bench", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

- Add `scripts/setup_mm_tsflib.sh` to clone MM-TSFlib and extract the Environment domain RAR data
- Add `scripts/run_mm_tsflib_benchmark.sh` to run MM-TSFlib on the same 5 domains tsfmx was trained on, with matching seq/pred lengths (32/32)
- Add `scripts/eval_tsfmx_checkpoint.py` to evaluate a tsfmx checkpoint and write per-domain MSE/MAE to JSON
- Add `scripts/compare_benchmark_results.py` to print a side-by-side comparison table
- Fix `scripts/split_time_mmd_datasets.py` to prepend a `context_len`-row overlap to val/test splits, matching MM-TSFlib's border convention so the first sample of each split has a full context window
- Update split ratio from 60/20/20 to 70/10/20 to match MM-TSFlib
- Add `bench`, `viz`, `sweep`, `all` optional extras to `pyproject.toml`
- Update `docker/Dockerfile` to install `libarchive-tools`, clone MM-TSFlib, and use the new split ratio

## Test plan

- [x] `./scripts/setup_mm_tsflib.sh` clones MM-TSFlib and extracts `data/Environment/NewYork_AQI_Day.csv`
- [x] `./scripts/run_mm_tsflib_benchmark.sh 0 Autoformer <HF_TOKEN>` completes for all 5 domains
- [x] `PYTHONPATH=. uv run python scripts/eval_tsfmx_checkpoint.py --checkpoint-path <path>` writes `outputs/tsfmx_eval_results.json`
- [x] `PYTHONPATH=. uv run python scripts/compare_benchmark_results.py` prints a comparison table

🤖 Generated with [Claude Code](https://claude.com/claude-code)