### PR TITLE
fix: add missing @override decorators to resolve ty type errors

### DIFF
--- a/examples/time_mmd/data/time_mmd_dataset.py
+++ b/examples/time_mmd/data/time_mmd_dataset.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from typing_extensions import override
 
 from examples.time_mmd.configs.domain_columns import DEFAULT_TIME_MMD_CONFIGS, DomainColumnConfig
 from tsfmx.data.dataset import MultimodalDatasetBase
@@ -396,10 +397,12 @@ class TimeMmdDataset(MultimodalDatasetBase):
         domains.sort()
         return domains
 
+    @override
     def __getitem__(self, index: int) -> RawSample:
         if index >= len(self.data):
             raise IndexError(f"Index {index} out of range for dataset of size {len(self.data)}")
         return self.data[index]
 
+    @override
     def __len__(self) -> int:
         return len(self.data)

--- a/src/tsfmx/data/dataset.py
+++ b/src/tsfmx/data/dataset.py
@@ -3,6 +3,7 @@
 from abc import ABC, abstractmethod
 
 from torch.utils.data import Dataset
+from typing_extensions import override
 
 from tsfmx.types import PreprocessedSample, RawSample, TrainingMode
 
@@ -10,6 +11,7 @@ from tsfmx.types import PreprocessedSample, RawSample, TrainingMode
 class MultimodalDatasetBase(Dataset[RawSample], ABC):
     """Abstract base class for multimodal time series datasets."""
 
+    @override
     @abstractmethod
     def __getitem__(self, index: int) -> RawSample: ...
 
@@ -36,6 +38,7 @@ class PreprocessedDataset(Dataset[PreprocessedSample]):
         if self.mode in ("fusion", "finetune") and not all("text_embeddings" in s for s in self.data):
             raise ValueError(f"All samples must contain 'text_embeddings' for {self.mode!r} mode")
 
+    @override
     def __getitem__(self, index: int) -> PreprocessedSample:
         return self.data[index]
 

--- a/src/tsfmx/decoder.py
+++ b/src/tsfmx/decoder.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from typing_extensions import override
+
 import torch
 from torch import nn
 
@@ -115,6 +117,7 @@ class MultimodalDecoder(nn.Module):
         output_embeddings = self.adapter(embeddings, preprocessed.masks)
         return self.adapter.postprocess(horizon, output_embeddings, preprocessed.normalization_stats)
 
+    @override
     def forward(
         self,
         horizon: int,

--- a/src/tsfmx/fusion.py
+++ b/src/tsfmx/fusion.py
@@ -2,6 +2,7 @@
 
 import torch
 from torch import nn
+from typing_extensions import override
 
 
 class MultimodalFusion(nn.Module):
@@ -41,6 +42,7 @@ class MultimodalFusion(nn.Module):
                 f"hidden_dims must have {num_layers - 1} elements for {num_layers} layers, got {len(hidden_dims)}"
             )
 
+    @override
     def forward(self, ts_embeddings: torch.Tensor, text_embeddings: torch.Tensor) -> torch.Tensor:
         """Project text_embeddings to ts_embedding_dims and add to ts_embeddings."""
         projected: torch.Tensor = self.projection(text_embeddings)

--- a/src/tsfmx/text_encoder/base.py
+++ b/src/tsfmx/text_encoder/base.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 import numpy as np
 import torch
 from torch import nn
+from typing_extensions import override
 
 from tsfmx.utils.device import resolve_device
 
@@ -23,6 +24,7 @@ class TextEncoderBase(nn.Module, ABC):
         self.embedding_dim = embedding_dim
         self.device = resolve_device(device)
 
+    @override
     @abstractmethod
     def forward(self, texts: str | list[str] | np.ndarray) -> torch.Tensor: ...
 

--- a/src/tsfmx/text_encoder/english.py
+++ b/src/tsfmx/text_encoder/english.py
@@ -3,6 +3,7 @@
 import numpy as np
 import torch
 from sentence_transformers import SentenceTransformer
+from typing_extensions import override
 
 from tsfmx.text_encoder.base import TextEncoderBase
 
@@ -32,6 +33,7 @@ class EnglishTextEncoder(TextEncoderBase):
         if actual_dim != self.embedding_dim:
             raise ValueError(f"Embedding dimension mismatch: expected {self.embedding_dim}, got {actual_dim}.")
 
+    @override
     def forward(self, texts: str | list[str] | np.ndarray) -> torch.Tensor:
         """Encode texts into embeddings.
 
@@ -43,10 +45,12 @@ class EnglishTextEncoder(TextEncoderBase):
         """
         return self.sentence_transformer.encode(texts, convert_to_tensor=True)
 
+    @override
     def freeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = False
 
+    @override
     def unfreeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = True

--- a/src/tsfmx/text_encoder/japanese.py
+++ b/src/tsfmx/text_encoder/japanese.py
@@ -3,6 +3,7 @@
 import numpy as np
 import torch
 from sentence_transformers import SentenceTransformer
+from typing_extensions import override
 
 from tsfmx.text_encoder.base import TextEncoderBase
 
@@ -35,6 +36,7 @@ class JapaneseTextEncoder(TextEncoderBase):
         if actual_dim != self.embedding_dim:
             raise ValueError(f"Embedding dimension mismatch: expected {self.embedding_dim}, got {actual_dim}.")
 
+    @override
     def forward(self, texts: str | list[str] | np.ndarray) -> torch.Tensor:
         """Encode texts into embeddings.
 
@@ -46,10 +48,12 @@ class JapaneseTextEncoder(TextEncoderBase):
         """
         return self.sentence_transformer.encode(texts, convert_to_tensor=True)
 
+    @override
     def freeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = False
 
+    @override
     def unfreeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = True

--- a/src/tsfmx/tsfm/base.py
+++ b/src/tsfmx/tsfm/base.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 
 import torch
 from torch import nn
+from typing_extensions import override
 
 
 @dataclass
@@ -53,6 +54,7 @@ class TsfmAdapter(nn.Module, ABC):
         masks: torch.Tensor,
     ) -> PreprocessResult: ...
 
+    @override
     @abstractmethod
     def forward(
         self,

--- a/src/tsfmx/tsfm/chronos.py
+++ b/src/tsfmx/tsfm/chronos.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import cast
 
+from typing_extensions import override
+
 import torch
 from chronos import Chronos2Model
 from huggingface_hub import hf_hub_download
@@ -20,18 +22,22 @@ class Chronos2Adapter(TsfmAdapter):
         super().__init__()
         self._model = model
 
+    @override
     @property
     def model_dims(self) -> int:
         return self._model.model_dim
 
+    @override
     @property
     def patch_len(self) -> int:
         return self._model.chronos_config.input_patch_size
 
+    @override
     @property
     def point_forecast_index(self) -> int:
         return list(self._model.chronos_config.quantiles).index(0.5)
 
+    @override
     def preprocess(
         self,
         inputs: torch.Tensor,
@@ -59,6 +65,7 @@ class Chronos2Adapter(TsfmAdapter):
             normalization_stats={"loc": loc, "scale": scale},
         )
 
+    @override
     def forward(
         self,
         input_embeddings: torch.Tensor,
@@ -125,6 +132,7 @@ class Chronos2Adapter(TsfmAdapter):
         hidden_states: torch.Tensor = encoder_outputs[0]
         return hidden_states[:, -num_output_patches:]
 
+    @override
     def postprocess(
         self,
         horizon: int,
@@ -198,10 +206,12 @@ class Chronos2Adapter(TsfmAdapter):
         instance.load_checkpoint(checkpoint_path)
         return instance
 
+    @override
     def freeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = False
 
+    @override
     def unfreeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = True

--- a/src/tsfmx/tsfm/timesfm.py
+++ b/src/tsfmx/tsfm/timesfm.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import torch
 from huggingface_hub import hf_hub_download
+from typing_extensions import override
 from safetensors.torch import load_file
 from timesfm.timesfm_2p5.timesfm_2p5_torch import TimesFM_2p5_200M_torch_module
 from timesfm.torch.util import revin, update_running_stats
@@ -19,18 +20,22 @@ class TimesFM2p5Adapter(TsfmAdapter):
         super().__init__()
         self._model = TimesFM_2p5_200M_torch_module()
 
+    @override
     @property
     def model_dims(self) -> int:
         return self._model.md
 
+    @override
     @property
     def patch_len(self) -> int:
         return self._model.p
 
+    @override
     @property
     def point_forecast_index(self) -> int:
         return self._model.config.decode_index
 
+    @override
     def preprocess(
         self,
         inputs: torch.Tensor,
@@ -80,6 +85,7 @@ class TimesFM2p5Adapter(TsfmAdapter):
             },
         )
 
+    @override
     def forward(
         self,
         input_embeddings: torch.Tensor,
@@ -95,6 +101,7 @@ class TimesFM2p5Adapter(TsfmAdapter):
             output_embeddings, _ = layer(output_embeddings, masks[..., -1], None)
         return output_embeddings
 
+    @override
     def postprocess(
         self,
         horizon: int,
@@ -155,10 +162,12 @@ class TimesFM2p5Adapter(TsfmAdapter):
         instance.load_checkpoint(checkpoint_path)
         return instance
 
+    @override
     def freeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = False
 
+    @override
     def unfreeze_parameters(self) -> None:
         for param in self.parameters():
             param.requires_grad = True


### PR DESCRIPTION
## Summary

- Adds `@override` decorators to all methods that override parent class methods across 10 files in `src/tsfmx/` and `examples/`
- Uses `from typing_extensions import override` for Python 3.11 compatibility (`typing.override` was added in 3.12)
- Removes erroneous `@override` from `PreprocessedDataset.__len__` — `torch.utils.data.Dataset` does not formally define `__len__`, so it is not an override

## Affected files

- `src/tsfmx/data/dataset.py`
- `src/tsfmx/decoder.py`
- `src/tsfmx/fusion.py`
- `src/tsfmx/text_encoder/base.py`, `english.py`, `japanese.py`
- `src/tsfmx/tsfm/base.py`, `chronos.py`, `timesfm.py`
- `examples/time_mmd/data/time_mmd_dataset.py`

## Test plan

- [x] `uv run ty check` — all checks passed
- [x] `uv run ruff check` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)