### PR TITLE
Release 1.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tsfmx"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
     "chronos-forecasting>=2.2.2",
     "numpy>=2.4.2",

--- a/uv.lock
+++ b/uv.lock
@@ -2116,7 +2116,7 @@ wheels = [
 
 [[package]]
 name = "tsfmx"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "chronos-forecasting" },


### PR DESCRIPTION
## Summary

- Bump version from 1.2.0 to 1.3.0

## Changes since 1.2.0

- feat: switch timesfm dependency from GitHub to PyPI (#277)
- feat: add MM-TSFlib benchmark scripts and comparison tooling (#274)
- feat: add PredictionVisualizer for per-sample forecast plots (#270)
- feat: add `MultimodalDecoder.load_checkpoint` and `.forecast`; simplify `MultimodalEvaluator`
- fix: add missing `@override` decorators (#276)
- fix: prepend context_len-row overlap to val/test splits
- chore: various dependency bumps

## Test plan

- [x] CI passes
- [x] PyPI publish workflow triggers on release

🤖 Generated with [Claude Code](https://claude.com/claude-code)